### PR TITLE
Update Go to 1.26 and Debian base to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.19-buster as builder
+FROM golang:1.26-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app
@@ -38,7 +38,7 @@ RUN go build -v -o server
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module try
 
-go 1.19
+go 1.26
 
 require (
 	github.com/labstack/echo/v4 v4.9.1


### PR DESCRIPTION
Bump go.mod to Go 1.26 (latest stable) and update the Dockerfile
builder/runtime images since the previous buster-based tags are EOL and
no longer receive matching golang image tags.